### PR TITLE
画面幅が広いときにフッターの文字が寄ってしまっていた。

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,10 +11,10 @@ html
 
   body
     = yield
-    footer.bg-gray-100.p-4.flex.justify-center.grid.grid-cols-1.sm:grid-cols-2
-      span.mr-4
+    footer.bg-gray-100.p-4.flex.justify-center.grid.grid-cols-1.sm:grid-cols-4
+      span.sm:col-start-2.sm:place-self-center
         | Author:
         = link_to "@yamat47", "https://twitter.com/yamat47", class: "ml-2 underline", target: "_blank"
-      span
+      span.sm:col-start-3.sm:place-self-center
         | GitHub:
         = link_to "yamat47/officials_card", "https://github.com/yamat47/officials-card", class: "ml-2 underline", target: "_blank"


### PR DESCRIPTION
修正内容
----

### before

![localhost_3000_ (2)](https://user-images.githubusercontent.com/20818166/104604375-a234a200-56c0-11eb-92c6-41d0cc4a3355.png)

### after

![localhost_3000_ (1)](https://user-images.githubusercontent.com/20818166/104604192-8d580e80-56c0-11eb-83c5-fe848e30d995.png)
